### PR TITLE
Added a green background when using the `/tag` command

### DIFF
--- a/chat-operators.user.js
+++ b/chat-operators.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Happychat Operators
 // @namespace    https://github.com/senff/Chat-operators
-// @version      1.5
+// @version      1.6
 // @description  List of operators
 // @author       Senff
 // @require      https://code.jquery.com/jquery-1.12.4.js
@@ -234,8 +234,13 @@ function highlightNote(){
     var entryField = boxContents.toLowerCase();
     if (entryField.startsWith('/note ')) {
         $('.chat-actions__current-chat-action-compose textarea').addClass('note');
+        $('.chat-actions__current-chat-action-compose textarea').removeClass('tag');
+    } else if (entryField.startsWith('/tag ')) {
+        $('.chat-actions__current-chat-action-compose textarea').addClass('tag');
+        $('.chat-actions__current-chat-action-compose textarea').removeClass('note');
     } else {
         $('.chat-actions__current-chat-action-compose textarea').removeClass('note');
+        $('.chat-actions__current-chat-action-compose textarea').removeClass('tag');
     }
 }
 

--- a/stylus.css
+++ b/stylus.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Happychat Operators
 @namespace      github.com/senff/Chat-operators
-@version        1.5
+@version        1.6
 @description    Make the Happychat Operators list easier to understand.
 @author         Senff
 @updateURL      https://raw.githubusercontent.com/senff/Chat-operators/master/stylus.css
@@ -15,22 +15,22 @@
         .chat__chat-queue .green {color:#4ab866;}
         .chat__chat-queue .yellow {color:#f0b849;}
         .chat__chat-queue .highlight {font-weight: bold;}
-     
-     
+
+
     /* --- Sidebar width --- */
         .chat__chat-queue {
             -ms-flex: 0 1 350px;
             flex: 0 1 350px;
             min-width: 350px;
         }
-     
-    /* --- Hide some stuff we don't need --- */    
+
+    /* --- Hide some stuff we don't need --- */
         .chat__chat-queue .operators__offline,
         .chat__chat-queue .operators.operators:before,
         .chat__chat-queue .operators__capacity {
             display: none;
         }
-     
+
     /* --- Operators box --- */
         .chat__chat-queue .capacity__operators {
             height: 300px;
@@ -47,12 +47,12 @@
         }
 
         #operatorData {
-            width:0; 
-            height: 0; 
-            font-size: 0; 
+            width:0;
+            height: 0;
+            font-size: 0;
             overflow: hidden;
         }
-     
+
     /* --- Each individual operator line --- */
         .chat__chat-queue .operators {
             display: block;
@@ -72,8 +72,8 @@
         .chat__chat-queue .operator_info:nth-of-type(1) {
             display: block;
         }
-     
-    /* --- Operator icon/name/load/etc. --- */    
+
+    /* --- Operator icon/name/load/etc. --- */
         .chat__chat-queue .operators img {
             float: left;
             margin-right: 5px;
@@ -82,13 +82,13 @@
             height: 23px;
             border: solid 3px transparent;
         }
-     
-            /* --- Avatar status colors --- */    
+
+            /* --- Avatar status colors --- */
             .chat__chat-queue .operators__available img {border-color:#4ab866;}
             .chat__chat-queue .operators__reserve img {border-color:#0087be;}
             .chat__chat-queue .operators__busy img {border-color:#f0b849;}
             .chat__chat-queue .operators__unavailable img {border-color:#d94f4f;}
-     
+
         .chat__chat-queue .operator_name {
             float:left;
             padding-right: 10px;
@@ -100,7 +100,7 @@
             max-width: 145px;
             white-space: nowrap;
             overflow: hidden;
-            text-overflow: ellipsis;  
+            text-overflow: ellipsis;
             display: inline-block;
         }
 
@@ -109,7 +109,7 @@
         .chat__chat-queue .operators__reserve .operator_name span {color: #0087be;}
         .chat__chat-queue .operators__busy .operator_name span {color: #dd9922;}
 
-        .chat__chat-queue .operator_name.es span::before, 
+        .chat__chat-queue .operator_name.es span::before,
         .chat__chat-queue .operator_name.pt-br::before {
             content: "";
             border-radius: 25px;
@@ -168,7 +168,7 @@
             text-align: right;
             font-size: 11px;
         }
-     
+
         .chat__chat-queue .operator_capacity {
             height: 8px;
             background: #e7e7e7;
@@ -188,14 +188,14 @@
         }
 
     /* border: solid 1px #d94f4f; height: 8px; margin-top:-1px; */
-     
+
         .chat__chat-queue .operator_ind {
             height: 100%;
             max-width: 100%;
             border-radius: 5px;
             float: right;
         }
-     
+
     /* --- Load/throttle colors --- */
         .capLevel0 .operator_ind,
         .capLevel1 .operator_ind,
@@ -209,7 +209,7 @@
         .capLevel9 .operator_ind {background: #ffaa22;}
         .capLevel10 .operator_ind {background: #d94f4f;}
         .capLevelOver .operator_ind {background: #660000;}
-     
+
     /* --- Additional stats --- */
         .operators_stats {
             margin: 10px;
@@ -296,6 +296,10 @@
             background-color: #FFFFCC;
         }
 
+        .chat__current-chat__actions textarea.tag {
+            background-color: #ddf1e2;
+        }
+
         .chat-panel__return-to-now {
             display: none;
         }
@@ -307,5 +311,5 @@
         .chat__current-chat__actions button {
             display: none;
         }
-    
+
 }


### PR DESCRIPTION
Updated to make tags show with a green background in chat:

![tagenhancement](https://user-images.githubusercontent.com/7596032/64064188-400ef600-cbcc-11e9-8103-1092f5e3d081.gif)
